### PR TITLE
Comment on bogus-ness of `PROVISIONING_PROFILE_SPECIFIER` for `PodsProjectGenerator`.

### DIFF
--- a/lib/cocoapods/installer/xcode/pods_project_generator.rb
+++ b/lib/cocoapods/installer/xcode/pods_project_generator.rb
@@ -138,7 +138,7 @@ module Pod
               build_configuration.build_settings['STRIP_INSTALLED_PRODUCT'] = 'NO'
               build_configuration.build_settings['CLANG_ENABLE_OBJC_ARC'] = 'YES'
               build_configuration.build_settings['CODE_SIGNING_REQUIRED'] = 'NO'
-              build_configuration.build_settings['PROVISIONING_PROFILE_SPECIFIER'] = 'NO_SIGNING/'
+              build_configuration.build_settings['PROVISIONING_PROFILE_SPECIFIER'] = 'NO_SIGNING/' # a bogus provisioning profile ID assumed to be invalid
             end
           end
         end


### PR DESCRIPTION
The specifier is definitely self-explanatory in what it does, but should be explicit about how it specifies: to achieve bogus-ness.

Regarding CocoaPods/CocoaPods#5528.

Via https://twitter.com/NeoNacho/status/753959283797192705

CC @neonichu 😄 
